### PR TITLE
Fix auth dependency and improve docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# work
+# Quiz App
+
+This repository contains a simple PHP quiz application. The `public/` directory
+is intended to be served as the document root, and the `includes/` directory
+provides helper functions for database access, authentication, and CSRF
+protection.
+
+## Setup
+
+1. Configure the database connection values in `includes/db.php`.
+2. Serve the `public/` directory with a PHP-capable web server.
+
+## Testing
+
+Run the included tests with:
+
+```bash
+php tests/csrf_test.php
+```
+

--- a/quiz-app/includes/auth.php
+++ b/quiz-app/includes/auth.php
@@ -1,6 +1,8 @@
 <?php
 // includes/auth.php
 
+require_once __DIR__ . '/db.php';
+
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
 }
@@ -29,3 +31,4 @@ function logout_admin(): void {
     }
     session_destroy();
 }
+

--- a/quiz-app/public/index.php
+++ b/quiz-app/public/index.php
@@ -28,7 +28,7 @@ $categories = $stmt->fetchAll();
       <div class="list">
         <?php foreach ($categories as $c): ?>
           <div class="card">
-            <div class="badge">カテゴリー</div>
+            <div class="badge">カテゴリ</div>
             <h3><?php echo e($c['name']); ?></h3>
             <a class="button" href="quiz.php?category_id=<?php echo (int)$c['id']; ?>">開始</a>
           </div>

--- a/tests/csrf_test.php
+++ b/tests/csrf_test.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../quiz-app/includes/csrf.php';
+
+// Token generation should be consistent within a session
+$token1 = csrf_token();
+assert(strlen($token1) === 64);
+$token2 = csrf_token();
+assert($token1 === $token2);
+
+// verify_csrf should accept a correct token
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_POST['_token'] = $token1;
+verify_csrf();
+
+echo "CSRF tests passed\n";


### PR DESCRIPTION
## Summary
- ensure auth helper loads database utilities
- standardize category badge text
- document project setup and testing
- add basic CSRF unit test

## Testing
- `php -l quiz-app/includes/auth.php`
- `php -l quiz-app/public/index.php`
- `php -l tests/csrf_test.php`
- `php tests/csrf_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689c3a89227483289c776abfcaede59c