### PR TITLE
Make category cards clickable and style as link

### DIFF
--- a/quiz-app/public/assets/styles.css
+++ b/quiz-app/public/assets/styles.css
@@ -32,6 +32,9 @@ body {
   font-weight: 700;
 }
 .card {
+  display: block;
+  color: inherit;
+  text-decoration: none;
   background: var(--panel);
   border-radius: 16px;
   box-shadow: 0 4px 16px rgba(2, 6, 23, 0.06);

--- a/quiz-app/public/index.php
+++ b/quiz-app/public/index.php
@@ -27,11 +27,11 @@ $categories = $stmt->fetchAll();
       <h2>カテゴリを選んで開始</h2>
       <div class="list">
         <?php foreach ($categories as $c): ?>
-          <div class="card">
+          <a class="card" href="quiz.php?category_id=<?php echo (int)$c['id']; ?>">
             <div class="badge">カテゴリ</div>
             <h3><?php echo e($c['name']); ?></h3>
             <a class="button" href="quiz.php?category_id=<?php echo (int)$c['id']; ?>">開始</a>
-          </div>
+          </a>
         <?php endforeach; ?>
       </div>
       <?php if (empty($categories)): ?>


### PR DESCRIPTION
## Summary
- Wrap each category card in a link so clicking anywhere starts the quiz
- Style card links to look like cards without link decoration

## Testing
- `php tests/csrf_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689c464fce6883288df0fc36db1ec50d