### PR TITLE
Make category cards clickable with hover styling

### DIFF
--- a/quiz-app/public/assets/styles.css
+++ b/quiz-app/public/assets/styles.css
@@ -41,6 +41,9 @@ body {
   padding: 16px;
   margin: 12px 0;
 }
+.category-card { position:relative; transition:box-shadow .2s, transform .2s; }
+.category-card:hover { transform:translateY(-2px); box-shadow:0 6px 20px rgba(0,0,0,.12); }
+.start-btn { margin-top:8px; display:inline-block; }
 .button {
   display: inline-block;
   padding: 10px 16px;

--- a/quiz-app/public/index.php
+++ b/quiz-app/public/index.php
@@ -27,17 +27,28 @@ $categories = $stmt->fetchAll();
       <h2>カテゴリを選んで開始</h2>
       <div class="list">
         <?php foreach ($categories as $c): ?>
-          <a class="card" href="quiz.php?category_id=<?php echo (int)$c['id']; ?>">
+          <div class="card category-card">
             <div class="badge">カテゴリ</div>
             <h3><?php echo e($c['name']); ?></h3>
-            <a class="button" href="quiz.php?category_id=<?php echo (int)$c['id']; ?>">開始</a>
-          </a>
+            <a class="button start-btn" href="quiz.php?category_id=<?php echo (int)$c['id']; ?>">開始</a>
+          </div>
         <?php endforeach; ?>
       </div>
       <?php if (empty($categories)): ?>
         <p>カテゴリがありません。管理画面から追加してください。</p>
       <?php endif; ?>
     </div>
+
+    <script>
+      document.querySelectorAll('.category-card').forEach(card => {
+        card.addEventListener('click', e => {
+          const link = card.querySelector('.start-btn');
+          if (link && !e.target.closest('.start-btn')) {
+            link.click();
+          }
+        });
+      });
+    </script>
 
     <footer class="footer">© Quiz App</footer>
   </div>


### PR DESCRIPTION
## Summary
- Refactor category listing to use div-based cards with separate start buttons
- Add JS handler so clicking a category card triggers its start button
- Introduce card hover and start button styles

## Testing
- `php tests/csrf_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689c4dc414bc8328807c81ea5c4f10e8