### PR TITLE
Redirect logged-in admins from login

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Run the included tests with:
 php tests/csrf_test.php
 ```
 
+## Persistent Login
+
+To keep administrators logged in for longer periods, increase
+`session.cookie_lifetime` or implement a token-based "Remember me" feature.
+

--- a/quiz-app/public/admin/login.php
+++ b/quiz-app/public/admin/login.php
@@ -3,6 +3,11 @@ require_once __DIR__ . '/../../includes/db.php';
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/csrf.php';
 
+if (is_logged_in()) {
+    header('Location: ' . base_path('admin/questions.php'));
+    exit;
+}
+
 verify_csrf();
 
 $error = '';


### PR DESCRIPTION
## Summary
- Redirect logged-in admins from the login page to the questions dashboard
- Document options for longer-lived sessions

## Testing
- `php tests/csrf_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689c4dc30e948328bc0d8a5d6b1c6eed